### PR TITLE
Engine: Fixed bug in `run_app` function

### DIFF
--- a/packages/racer/engine/engine.h
+++ b/packages/racer/engine/engine.h
@@ -19,7 +19,7 @@ App create_app(std::string_view name) { return App{ .name = name }; }
 
 void run_app(App const& app)
 {
-  sf::RenderWindow window(sf::VideoMode(1920, 1080), app.name.cbegin());
+  sf::RenderWindow window(sf::VideoMode(1920, 1080), app.name.data());
   sf::View view(sf::FloatRect(0, 0, COORDINATE_SPACE_WIDTH, COORDINATE_SPACE_HEIGHT));
   window.setView(view);
 

--- a/packages/racer/main.cpp
+++ b/packages/racer/main.cpp
@@ -7,7 +7,7 @@ int main()
 {
   auto app = engine::create_app("RACER");
 
-  engine::spawn_entity<Circle>(app, sf::Vector2f{ 0.0f, 0.0f }, 100);
+  engine::spawn_entity<Circle>(app, sf::Vector2f{ 0.0f, 0.0f }, 100.f);
 
   engine::run_app(app);
 


### PR DESCRIPTION
We were calling `cbegin()` to get a pointer to the underlying data,
however, this actually returns an iterator. MSVC complains about
receiving an iterator when it expected a pointer. We now use `data()`,
which returns a pointer to the cstring.

Also fixed a bug in `main.cpp` where we were passing an int to the
Circle constructor that expects a float.