### PR TITLE
Move to using `FetchContent` for dependencies

### DIFF
--- a/packages/racer/CMakeLists.txt
+++ b/packages/racer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 # Specify C++ standard
 set(CMAKE_CXX_STANDARD 20)

--- a/packages/racer/engine/CMakeLists.txt
+++ b/packages/racer/engine/CMakeLists.txt
@@ -1,8 +1,17 @@
 
 add_library(engine app.cpp)
 
-# Find SFML shared libraries
-find_package(SFML 2.5 COMPONENTS system window graphics audio REQUIRED)
+# Add FetchContent module
+include(FetchContent)
+
+# Fetch SFML
+FetchContent_Declare(
+ SFML
+ GIT_REPOSITORY https://github.com/SFML/SFML.git
+ GIT_TAG 2.6.x
+)
+FetchContent_MakeAvailable(SFML)
+
 
 # Link executable to required SFML modules
 target_link_libraries(engine sfml-graphics)


### PR DESCRIPTION
Previously, we were relying on SFML being installed correctly on the
host machine we are compiling on. Now we fetch SFML from their git
repository. We also use version `2.6.x` rather than `2.5`.