### PR TITLE
Improved the engine's main loop

### DIFF
--- a/engine/engine.h
+++ b/engine/engine.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <cstdint>
 
 #include "app.h"
 
@@ -13,6 +14,7 @@ namespace detail
   void scale_view_to_window_size(sf::RenderWindow&);
 }// namespace detail
 
+std::uint64_t MS_PER_FRAME = 12;
 float const COORDINATE_SPACE_WIDTH = 2000;
 float const COORDINATE_SPACE_HEIGHT = 1000;
 auto const ASPECT_RATIO = COORDINATE_SPACE_WIDTH / COORDINATE_SPACE_HEIGHT;
@@ -27,11 +29,24 @@ void run_app(App const& app)
 
   detail::scale_view_to_window_size(window);
 
+  sf::Clock clock;
+  std::uint64_t total_time_since_render{};
   while (window.isOpen()) {
-    window.clear();
     detail::handle_events(window);
-    for (auto entity : app.entities) { entity->render(window); }
-    window.display();
+    sf::Time const elapsed = clock.restart();
+    std::uint64_t const elapsed_milliseconds = elapsed.asMilliseconds();
+
+    total_time_since_render += elapsed_milliseconds;
+
+    // We would update the entities here:
+    // for (auto entity : app.entities) { entity->update(elapsed_milliseconds); }
+
+    if (total_time_since_render > MS_PER_FRAME) {
+      total_time_since_render -= MS_PER_FRAME;
+      window.clear();
+      for (auto entity : app.entities) { entity->render(window); }
+      window.display();
+    }
   }
 }
 


### PR DESCRIPTION
Previously, we would render the state of the game on every iteration of the main loop. This means that updating the state of the game is blocked by rendering.

Now, we throttle the rendering to 60 FPS, meaning that we will have more time to simulate the physics, rather than spending all of our time rendering.